### PR TITLE
Aab computer search

### DIFF
--- a/Bangazon-Workforce/Controllers/ComputersController.cs
+++ b/Bangazon-Workforce/Controllers/ComputersController.cs
@@ -27,7 +27,7 @@ namespace Bangazon_Workforce.Controllers
             }
         }
         // GET: Computers
-        public ActionResult Index()
+        public ActionResult Index(string searchString)
         {
             using (SqlConnection conn = Connection)
             {
@@ -35,10 +35,17 @@ namespace Bangazon_Workforce.Controllers
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = @"SELECT Id, Make, Model, PurchaseDate
-                                        FROM Computer";
+                                        FROM Computer ";
+
+                    if (!string.IsNullOrEmpty(searchString))
+                    {
+                        cmd.CommandText += @"WHERE Make LIKE @searchString OR Model LIKE @searchString";
+                        cmd.Parameters.Add(new SqlParameter("@searchString", "%" + searchString + "%"));
+                    }
 
                     var reader = cmd.ExecuteReader();
                     var computers = new List<Computer>();
+
 
                     while (reader.Read())
                     {

--- a/Bangazon-Workforce/Controllers/ComputersController.cs
+++ b/Bangazon-Workforce/Controllers/ComputersController.cs
@@ -46,7 +46,6 @@ namespace Bangazon_Workforce.Controllers
                     var reader = cmd.ExecuteReader();
                     var computers = new List<Computer>();
 
-
                     while (reader.Read())
                     {
                         computers.Add(new Computer()

--- a/Bangazon-Workforce/Views/Computers/Index.cshtml
+++ b/Bangazon-Workforce/Views/Computers/Index.cshtml
@@ -9,6 +9,12 @@
 <p>
     <a asp-action="Create">Create New</a>
 </p>
+<form asp-controller="Computers" asp-action="Index">
+    <p>
+        Search Computers: <input type="text" name="searchString">
+        <input type="submit" value="Filter" />
+    </p>
+</form>
 <table class="table">
     <thead>
         <tr>


### PR DESCRIPTION
# Description
Given a user wants to view specific computers by make or manufacturer
When the user views the computer list
Then the user should have an affordance to type in the name of a computer make or computer manufacturer

Given the user has entered in the name of a computer make || manufacturer in the computer filter affordance
When the user presses the enter key
Then the computer list should be re-rendered with computers that matches the make || manufacturer


Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# Testing Instructions

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
