### PR TITLE
removed decomission date from computer details if computer doesn't have…

### DIFF
--- a/Bangazon-Workforce/Controllers/ComputersController.cs
+++ b/Bangazon-Workforce/Controllers/ComputersController.cs
@@ -49,7 +49,6 @@ namespace Bangazon_Workforce.Controllers
 
                     var reader = cmd.ExecuteReader();
                     var computers = new List<Computer>();
-                    Employee employee = null;
 
                     while (reader.Read())
                     {

--- a/Bangazon-Workforce/Views/Computers/Details.cshtml
+++ b/Bangazon-Workforce/Views/Computers/Details.cshtml
@@ -16,12 +16,15 @@
         <dd class="col-sm-10">
             @Html.DisplayFor(model => model.PurchaseDate)
         </dd>
-        <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.DecomissionDate)
-        </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.DecomissionDate)
-        </dd>
+        @if (Model.DecomissionDate != null)
+        {
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => model.DecomissionDate)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.DecomissionDate)
+            </dd>
+        }
         <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.Make)
         </dt>

--- a/Bangazon-Workforce/Views/Computers/Index.cshtml
+++ b/Bangazon-Workforce/Views/Computers/Index.cshtml
@@ -35,7 +35,7 @@
                     @Html.ActionLink(item.Model, "Details", new { id = item.Id })
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Employee.FirstName)  @Html.DisplayFor(modelItem => item.Employee.LastName)
+                    @Html.DisplayFor(model => item.Employee.FirstName)  @Html.DisplayFor(model => item.Employee.LastName)
                 </td>
             </tr>
         }


### PR DESCRIPTION
… decommission date

# Description
Decommission date will not be shown in computer details if computer does not have a decommission date

# Testing Instructions
Start server and choose computers from navbar. Click on model of computer and user should only see decommission date if the computer has a decommission date.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
